### PR TITLE
Add cmake support for static library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,15 @@ set(TARGET_SRC ${CMAKE_CURRENT_LIST_DIR}/glog/logging.cc)
 set(TARGET_HDR ${CMAKE_CURRENT_LIST_DIR}/glog/logging.h)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-add_library(miniglog SHARED ${TARGET_SRC} ${TARGET_HDR})
+
+# option to build either a shared or a static library. default: shared
+option (BUILD_SHARED "Build shared library" ON)
+
+if (BUILD_SHARED)
+    add_library(miniglog SHARED ${TARGET_SRC} ${TARGET_HDR})
+else (BUILD_SHARED)
+    add_library(miniglog STATIC ${TARGET_SRC} ${TARGET_HDR})
+endif (BUILD_SHARED)
 
 # when other libraries or executables link to <target>.
 target_include_directories(miniglog PUBLIC
@@ -25,6 +33,7 @@ install(
     TARGETS miniglog
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
     )
 
 install(FILES glog/logging.h DESTINATION include/glog)


### PR DESCRIPTION
set BUILD_SHARED to off for building a static library.